### PR TITLE
pass user id to remove user. fixes #553

### DIFF
--- a/app/views/roles/edit.html.erb
+++ b/app/views/roles/edit.html.erb
@@ -1,0 +1,26 @@
+<h2>Role:</h2>
+<%= bootstrap_form_for @role, :url=>role_management.role_path(@role) do |f| %>
+  <%= f.text_field :name, :label=> "Role Name" %>
+
+    <%= f.submit "Update" %>
+
+<% end %>
+<% if can? :destroy, Role %>
+  <%= button_to "Delete", role_management.role_path(@role), :method=>:delete, :class=>'btn btn-danger' %>
+<% end %>
+<h3>Accounts</h3>
+<ul>
+  <% @role.users.each do |user| %>
+    <li id=<%= user.user_key %>><%= user.user_key %>
+      <% if can? :remove_user, Role %>
+        <%= button_to "Remove User", role_management.role_user_path(@role, user.id), :method=>:delete, :class=>'btn btn-danger' %>
+      <% end %>
+    </li>
+  <% end %>
+</ul>
+<h3>Add New Account</h3>
+<%= bootstrap_form_tag :url=> role_management.role_users_path(@role) do |f| %>
+  <%= f.text_field 'user_key', :label=>"User" %>
+  <%= f.submit "Add" %>
+  <%= link_to "Cancel", role_management.roles_path, :class => 'btn btn-default' %>
+<% end %>

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -5,8 +5,11 @@ feature 'Admin', :type => :feature do
 
   context 'admin user' do
     let(:user) { FactoryGirl.create(:admin_user) }
+    let(:non_admin) { FactoryGirl.create(:user) }
 
     before do
+      Role.create!(name: 'admin')
+      user.add_role('admin')
       login_as(user)
     end
 
@@ -18,6 +21,7 @@ feature 'Admin', :type => :feature do
       expect(page).to have_link('Statistics')
       expect(page).to have_link('Create a new user')
       expect(page).to have_link('Create a new role')
+      expect(page).to have_link('admin')
     end
 
     describe 'creating a user' do
@@ -99,6 +103,26 @@ feature 'Admin', :type => :feature do
           expect(current_path).to eq('/users/new')
           expect(page).to have_text('User someid already exists')
         end
+      end
+    end
+    
+    describe 'user role management' do
+      it 'adds/removes user from admin roles' do
+        visit '/roles'
+        click_link 'admin'
+        
+        expect(page).to_not have_text(non_admin.username)
+        
+        fill_in 'User', with: non_admin.username
+        click_button 'Add'
+        
+        expect(page).to have_text(non_admin.username)
+        
+        within("##{non_admin.username}") {
+          click_button "Remove User"
+        }
+        
+        expect(page).to_not have_text(non_admin.username)
       end
     end
   end


### PR DESCRIPTION
not sure why, but it was previously passing the username instead. 