### PR TITLE
allow twitterbot to crawl dh. fixes #573

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,12 @@
+User-agent: Twitterbot
+Allow: /downloads
+Allow: /catalog
+Allow: /catalog?page*
+Disallow: /catalog?*
+Disallow: /catalog/*
+Disallow: /contact
+Disallow: /users
+
 User-agent: *
 Allow: /catalog
 Allow: /catalog?page*


### PR DESCRIPTION
Using twitter card validator, https://cards-dev.twitter.com/validator, our robots.txt disallow crawling to the path of the image. 