### PR TITLE
[#672] Handle Abusive Requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,3 +106,5 @@ gem 'savon', '~> 2.11.0'
 gem 'nokogiri', '~> 1.8.1'
 
 gem 'puma'
+
+gem 'rack-attack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -467,6 +467,8 @@ GEM
       rails (>= 4.2.0, < 6.0)
       rdf
     rack (1.6.10)
+    rack-attack (6.0.0)
+      rack (>= 1.0, < 3)
     rack-mini-profiler (0.10.7)
       rack (>= 1.2.0)
     rack-protection (1.5.5)
@@ -820,6 +822,7 @@ DEPENDENCIES
   pry-rails
   puma
   qa
+  rack-attack
   rack-mini-profiler
   rails (= 4.2.7)
   rdf-vocab
@@ -850,4 +853,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,5 +25,7 @@ module GalterSufia
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+
+    config.middleware.use Rack::Attack
   end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -93,6 +93,12 @@ namespace :config do
     Allow from all
     # Block Northwestern Google bot, it was hitting us 500/minutes for days
     Deny from 129.105.16.40
+    # Block known subnets that were hitting us 1000s/hr
+    Deny from 119.39.94.0/24
+    Deny from 117.45.252.0/24
+    Deny from 183.27.51.0/24
+    Deny from 101.24.176.0/24
+    Deny from 125.127.0.0/16
   </Directory>
 </VirtualHost>
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,40 @@
+class Rack::Attack
+  # cache store
+  Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+
+  # whitelist NU network
+  safelist_ip("165.124.0.0/16")
+  safelist_ip("129.105.0.0/16")
+
+  # Always allow requests from localhost
+  # (blocklist & throttles are skipped)
+  Rack::Attack.safelist('allow from localhost') do |req|
+    '127.0.0.1' == req.ip || '::1' == req.ip
+  end
+
+  # These include some requests by the application, and not by the user
+  Rack::Attack.safelist('ignorable paths') do |req|
+    req.fullpath.start_with?('/assets',
+                             '/users/notifications_number', 
+                             '/catalog/facet/tags_sim.json',
+                             '/downloads/')
+  end
+
+  catalog_limit_proc = proc { |req| req.env['warden'].user.blank? ? 10 : 500 }
+  # Throttle /catalog by subnet
+  # 500/6mins for authenticated, 10/6mins for unauthenticated
+  # Key: "rack::attack:#{Time.now.to_i/:period}:catalog/subnet:#{subnet of req.ip}"
+  throttle('catalog/subnet', limit: catalog_limit_proc, period: 6.minutes) do |req|
+    if req.fullpath.start_with?('/catalog?', '/catalog/') && !req.fullpath.start_with?('/catalog?page')
+      req.ip.slice(0..req.ip.rindex("."))
+    end
+  end
+
+  all_limit_proc = proc { |req| req.env['warden'].user.blank? ? 100 : 1000 }
+  # Throttle all requests by subnet
+  # 1000/6mins for for authenticated, 100/6mins for unauthenticated
+  # Key: "rack::attack:#{Time.now.to_i/:period}:req/subnet:#{subnet of req.ip}"
+  throttle('req/subnet', limit: all_limit_proc, period: 6.minutes) do |req|
+    req.ip.slice(0..req.ip.rindex("."))
+  end
+end

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -229,5 +229,5 @@ production:
 # here.  By default, the staging environment has the agent turned on.
 staging:
   <<: *default_settings
-  monitor_mode: true
+  monitor_mode: false 
   app_name: DigitalHub (Staging)

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -1,0 +1,242 @@
+require 'rails_helper'
+
+RSpec.describe 'Rack::Attack.throttle', :type => :request do
+  before do
+    @period = 6.minutes
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+  end
+
+  it 'includes throttle keys' do
+    expect(Rack::Attack.throttles.keys).to match_array(['req/subnet', 'catalog/subnet'])
+  end
+
+  context 'safelisted ips' do
+    describe 'localhost 127.0.0.1'do
+      before do
+        get '/', {}, 'REMOTE_ADDR' => '127.0.0.1'
+      end
+
+      it 'success status' do
+        expect(response.status).to eq(200)
+      end
+
+      it 'does not track the ip' do
+        expect(request.env['rack.attack.matched']).to eq('allow from localhost')
+        expect(request.env['rack.attack.match_type']).to eq(:safelist)
+        expect(request.env['rack.attack.match_data']).to_not be_present
+        expect(request.env['REMOTE_ADDR']).to eq('127.0.0.1')
+      end
+    end
+
+    describe 'localhost ::1' do
+      before do
+        get '/', {}, 'REMOTE_ADDR' => '::1'
+      end
+
+      it 'success status' do
+        expect(response.status).to eq(200)
+      end
+
+      it 'does not track the ip' do
+        expect(request.env['rack.attack.matched']).to eq('allow from localhost')
+        expect(request.env['rack.attack.match_type']).to eq(:safelist)
+        expect(request.env['rack.attack.match_data']).to_not be_present
+        expect(request.env['REMOTE_ADDR']).to eq('::1')
+      end
+    end
+
+    describe 'NU network 165.214.0.0/16' do
+      before do
+        get '/', {}, 'REMOTE_ADDR' => '165.124.124.32'
+      end
+
+      it 'success status' do
+        expect(response.status).to eq(200)
+      end
+
+      it 'does not track the ip' do
+        expect(request.env['rack.attack.match_type']).to eq(:safelist)
+        expect(request.env['rack.attack.match_data']).to_not be_present
+        expect(request.env['REMOTE_ADDR']).to eq('165.124.124.32')
+      end
+    end
+
+    describe 'NU network 129.105.0.0/16' do
+      before do
+        get '/', {}, 'REMOTE_ADDR' => '129.105.215.146'
+      end
+
+      it 'success status' do
+        expect(response.status).to eq(200)
+      end
+
+      it 'does not track the ip' do
+        expect(request.env['rack.attack.match_type']).to eq(:safelist)
+        expect(request.env['rack.attack.match_data']).to_not be_present
+        expect(request.env['REMOTE_ADDR']).to eq('129.105.215.146')
+      end
+    end
+  end
+
+  context 'throttle subnets' do
+    describe 'not signed in user' do
+      context 'all paths' do
+        before do
+          @epoch_time = Time.now.to_i
+          get '/', {}, 'REMOTE_ADDR' => '1.2.3.4'
+        end
+
+        it 'counts the subnet' do
+          key = "rack::attack:#{(Time.now.to_i/@period).to_i}:req/subnet:1.2.3."
+          expect(Rack::Attack.cache.store.read(key)).to eq(1)
+        end
+
+        it 'tracks the subnet' do
+          data = { :count => 1, :limit => 100, :period => @period.to_i, :epoch_time => @epoch_time }
+          expect(request.env['rack.attack.throttle_data']['req/subnet']).to eq(data)
+          expect(request.env['REMOTE_ADDR']).to eq('1.2.3.4')
+        end
+
+        it 'suppresses the subnet' do
+          key = "rack::attack:#{(Time.now.to_i/@period).to_i}:req/subnet:1.2.3."
+          Rack::Attack.cache.store.increment(key, 99)
+          @epoch_time = Time.now.to_i
+          get '/about', {}, 'REMOTE_ADDR' => '1.2.3.5'
+
+          data = { :count => 101, :limit => 100, :period => @period.to_i, :epoch_time => @epoch_time }
+
+          expect(response.status).to eq(429)
+          expect(response.headers['Retry-After']).to eq(@period.to_s)
+          expect(Rack::Attack.cache.store.read(key)).to eq(101)
+          expect(request.env['rack.attack.throttle_data']['req/subnet']).to eq(data)
+        end
+      end # all paths
+
+      context '/catalog(?|/) paths' do
+        before do
+          @epoch_time = Time.now.to_i
+          get '/catalog?q=test', {}, 'REMOTE_ADDR' => '1.2.3.4'
+        end
+
+        it 'counts the subnet' do
+          key = "rack::attack:#{(Time.now.to_i/@period).to_i}:catalog/subnet:1.2.3."
+          expect(Rack::Attack.cache.store.read(key)).to eq(1)
+        end
+
+        it 'does not count /catalog only' do
+          get '/catalog', {}, 'REMOTE_ADDR' => '1.2.3.4'
+
+          key = "rack::attack:#{(Time.now.to_i/@period).to_i}:catalog/subnet:1.2.3."
+          expect(Rack::Attack.cache.store.read(key)).to eq(1)
+        end
+
+        it 'tracks the subnet' do
+          data = { :count => 1, :limit => 10, :period => @period.to_i, :epoch_time => @epoch_time }
+          expect(request.env['rack.attack.throttle_data']['catalog/subnet']).to eq(data)
+          expect(request.env['REMOTE_ADDR']).to eq('1.2.3.4')
+        end
+
+        it 'suppresses the subnet' do
+          key = "rack::attack:#{(Time.now.to_i/@period).to_i}:catalog/subnet:1.2.3."
+          Rack::Attack.cache.store.increment(key, 9)
+          @epoch_time = Time.now.to_i
+          get '/catalog/suppressed', {}, 'REMOTE_ADDR' => '1.2.3.5'
+
+          data = { :count => 11, :limit => 10, :period => @period.to_i, :epoch_time => @epoch_time }
+
+          expect(response.status).to eq(429)
+          expect(response.headers['Retry-After']).to eq(@period.to_s)
+          expect(Rack::Attack.cache.store.read(key)).to eq(11)
+          expect(request.env['rack.attack.throttle_data']['catalog/subnet']).to eq(data)
+        end
+      end # /catalog paths
+    end # not signed in user
+
+    describe 'signed in user' do
+      let(:user) { create(:user) }
+
+      before do
+        RSpec.configure do |config|
+          config.include Warden::Test::Helpers
+        end
+
+        login_as user
+      end
+
+      context 'all paths' do
+        before do
+          @epoch_time = Time.now.to_i
+          get '/', {}, 'REMOTE_ADDR' => '1.2.3.4'
+        end
+
+        it 'counts the subnet' do
+          key = "rack::attack:#{(Time.now.to_i/@period).to_i}:req/subnet:1.2.3."
+          expect(Rack::Attack.cache.store.read(key)).to eq(1)
+        end
+
+        it 'tracks the subnet' do
+          data = { :count => 1, :limit => 1000, :period => @period.to_i, :epoch_time => @epoch_time }
+          expect(request.env['rack.attack.throttle_data']['req/subnet']).to eq(data)
+          expect(request.env['REMOTE_ADDR']).to eq('1.2.3.4')
+        end
+
+        it 'suppresses the subnet' do
+          key = "rack::attack:#{(Time.now.to_i/@period).to_i}:req/subnet:1.2.3."
+          Rack::Attack.cache.store.increment(key, 999)
+          @epoch_time = Time.now.to_i
+          get '/about', {}, 'REMOTE_ADDR' => '1.2.3.5'
+
+          data = { :count => 1001, :limit => 1000, :period => @period.to_i, :epoch_time => @epoch_time }
+
+          expect(response.status).to eq(429)
+          expect(response.headers['Retry-After']).to eq(@period.to_s)
+          expect(Rack::Attack.cache.store.read(key)).to eq(1001)
+          expect(request.env['rack.attack.throttle_data']['req/subnet']).to eq(data)
+        end
+      end # all paths
+
+      context '/catalog(?|/) paths' do
+        before do
+          @epoch_time = Time.now.to_i
+          get '/catalog?q=test', {}, 'REMOTE_ADDR' => '1.2.3.4'
+        end
+
+        it 'counts the subnet' do
+          key = "rack::attack:#{(Time.now.to_i/@period).to_i}:catalog/subnet:1.2.3."
+          expect(Rack::Attack.cache.store.read(key)).to eq(1)
+        end
+
+        it 'does not count /catalog only' do
+          get '/catalog', {}, 'REMOTE_ADDR' => '1.2.3.4'
+
+          key = "rack::attack:#{(Time.now.to_i/@period).to_i}:catalog/subnet:1.2.3."
+          expect(Rack::Attack.cache.store.read(key)).to eq(1)
+        end
+
+        it 'tracks the subnet' do
+          data = { :count => 1, :limit => 500, :period => @period.to_i, :epoch_time => @epoch_time }
+          expect(request.env['rack.attack.throttle_data']['catalog/subnet']).to eq(data)
+          expect(request.env['REMOTE_ADDR']).to eq('1.2.3.4')
+        end
+
+        it 'suppresses the subnet' do
+          key = "rack::attack:#{(Time.now.to_i/@period).to_i}:catalog/subnet:1.2.3."
+          Rack::Attack.cache.store.increment(key, 499)
+          @epoch_time = Time.now.to_i
+          get '/catalog/suppressed', {}, 'REMOTE_ADDR' => '1.2.3.5'
+
+          data = { :count => 501, :limit => 500, :period => @period.to_i, :epoch_time => @epoch_time }
+
+          expect(response.status).to eq(429)
+          expect(response.headers['Retry-After']).to eq(@period.to_s)
+          expect(Rack::Attack.cache.store.read(key)).to eq(501)
+          expect(request.env['rack.attack.throttle_data']['catalog/subnet']).to eq(data)
+        end
+      end # /catalog paths
+    end # signed in user
+  end
+
+  after(:all) do
+    Rack::Attack.clear_configuration
+  end
+end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Rack::Attack.throttle', :type => :request do
   before do
-    @period = 6.minutes
+    @period = 1.hour
     Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
   end
 
@@ -45,7 +45,7 @@ RSpec.describe 'Rack::Attack.throttle', :type => :request do
       end
     end
 
-    describe 'NU network 165.214.0.0/16' do
+    describe 'NU network 165.124.0.0/16' do
       before do
         get '/', {}, 'REMOTE_ADDR' => '165.124.124.32'
       end
@@ -92,22 +92,23 @@ RSpec.describe 'Rack::Attack.throttle', :type => :request do
         end
 
         it 'tracks the subnet' do
-          data = { :count => 1, :limit => 100, :period => @period.to_i, :epoch_time => @epoch_time }
+          data = { :count => 1, :limit => 1000,
+                   :period => @period.to_i, :epoch_time => @epoch_time }
           expect(request.env['rack.attack.throttle_data']['req/subnet']).to eq(data)
           expect(request.env['REMOTE_ADDR']).to eq('1.2.3.4')
         end
 
         it 'suppresses the subnet' do
           key = "rack::attack:#{(Time.now.to_i/@period).to_i}:req/subnet:1.2.3."
-          Rack::Attack.cache.store.increment(key, 99)
+          Rack::Attack.cache.store.increment(key, 999)
           @epoch_time = Time.now.to_i
+
           get '/about', {}, 'REMOTE_ADDR' => '1.2.3.5'
-
-          data = { :count => 101, :limit => 100, :period => @period.to_i, :epoch_time => @epoch_time }
-
+          data = { :count => 1001, :limit => 1000,
+                   :period => @period.to_i, :epoch_time => @epoch_time }
           expect(response.status).to eq(429)
           expect(response.headers['Retry-After']).to eq(@period.to_s)
-          expect(Rack::Attack.cache.store.read(key)).to eq(101)
+          expect(Rack::Attack.cache.store.read(key)).to eq(1001)
           expect(request.env['rack.attack.throttle_data']['req/subnet']).to eq(data)
         end
       end # all paths
@@ -131,23 +132,26 @@ RSpec.describe 'Rack::Attack.throttle', :type => :request do
         end
 
         it 'tracks the subnet' do
-          data = { :count => 1, :limit => 10, :period => @period.to_i, :epoch_time => @epoch_time }
+          data = { :count => 1, :limit => 100,
+                   :period => @period.to_i, :epoch_time => @epoch_time }
           expect(request.env['rack.attack.throttle_data']['catalog/subnet']).to eq(data)
           expect(request.env['REMOTE_ADDR']).to eq('1.2.3.4')
         end
 
         it 'suppresses the subnet' do
           key = "rack::attack:#{(Time.now.to_i/@period).to_i}:catalog/subnet:1.2.3."
-          Rack::Attack.cache.store.increment(key, 9)
+          Rack::Attack.cache.store.increment(key, 99)
           @epoch_time = Time.now.to_i
+
           get '/catalog/suppressed', {}, 'REMOTE_ADDR' => '1.2.3.5'
-
-          data = { :count => 11, :limit => 10, :period => @period.to_i, :epoch_time => @epoch_time }
-
+          data = { :count => 101, :limit => 100,
+                   :period => @period.to_i, :epoch_time => @epoch_time }
           expect(response.status).to eq(429)
           expect(response.headers['Retry-After']).to eq(@period.to_s)
-          expect(Rack::Attack.cache.store.read(key)).to eq(11)
-          expect(request.env['rack.attack.throttle_data']['catalog/subnet']).to eq(data)
+          expect(Rack::Attack.cache.store.read(key)).to eq(101)
+          expect(
+            request.env['rack.attack.throttle_data']['catalog/subnet']
+          ).to eq(data)
         end
       end # /catalog paths
     end # not signed in user
@@ -175,22 +179,23 @@ RSpec.describe 'Rack::Attack.throttle', :type => :request do
         end
 
         it 'tracks the subnet' do
-          data = { :count => 1, :limit => 1000, :period => @period.to_i, :epoch_time => @epoch_time }
+          data = { :count => 1, :limit => 10000,
+                   :period => @period.to_i, :epoch_time => @epoch_time }
           expect(request.env['rack.attack.throttle_data']['req/subnet']).to eq(data)
           expect(request.env['REMOTE_ADDR']).to eq('1.2.3.4')
         end
 
         it 'suppresses the subnet' do
           key = "rack::attack:#{(Time.now.to_i/@period).to_i}:req/subnet:1.2.3."
-          Rack::Attack.cache.store.increment(key, 999)
+          Rack::Attack.cache.store.increment(key, 9999)
           @epoch_time = Time.now.to_i
+
           get '/about', {}, 'REMOTE_ADDR' => '1.2.3.5'
-
-          data = { :count => 1001, :limit => 1000, :period => @period.to_i, :epoch_time => @epoch_time }
-
+          data = { :count => 10001, :limit => 10000,
+                   :period => @period.to_i, :epoch_time => @epoch_time }
           expect(response.status).to eq(429)
           expect(response.headers['Retry-After']).to eq(@period.to_s)
-          expect(Rack::Attack.cache.store.read(key)).to eq(1001)
+          expect(Rack::Attack.cache.store.read(key)).to eq(10001)
           expect(request.env['rack.attack.throttle_data']['req/subnet']).to eq(data)
         end
       end # all paths
@@ -214,22 +219,23 @@ RSpec.describe 'Rack::Attack.throttle', :type => :request do
         end
 
         it 'tracks the subnet' do
-          data = { :count => 1, :limit => 500, :period => @period.to_i, :epoch_time => @epoch_time }
+          data = { :count => 1, :limit => 5000,
+                   :period => @period.to_i, :epoch_time => @epoch_time }
           expect(request.env['rack.attack.throttle_data']['catalog/subnet']).to eq(data)
           expect(request.env['REMOTE_ADDR']).to eq('1.2.3.4')
         end
 
         it 'suppresses the subnet' do
           key = "rack::attack:#{(Time.now.to_i/@period).to_i}:catalog/subnet:1.2.3."
-          Rack::Attack.cache.store.increment(key, 499)
+          Rack::Attack.cache.store.increment(key, 4999)
           @epoch_time = Time.now.to_i
+
           get '/catalog/suppressed', {}, 'REMOTE_ADDR' => '1.2.3.5'
-
-          data = { :count => 501, :limit => 500, :period => @period.to_i, :epoch_time => @epoch_time }
-
+          data = { :count => 5001, :limit => 5000,
+                   :period => @period.to_i, :epoch_time => @epoch_time }
           expect(response.status).to eq(429)
           expect(response.headers['Retry-After']).to eq(@period.to_s)
-          expect(Rack::Attack.cache.store.read(key)).to eq(501)
+          expect(Rack::Attack.cache.store.read(key)).to eq(5001)
           expect(request.env['rack.attack.throttle_data']['catalog/subnet']).to eq(data)
         end
       end # /catalog paths


### PR DESCRIPTION
Use rack-attack to throttle requests. Based on recent events, we
track subnets and set limits based on:
- if a user is signed in or not
- if the request path is to /catalog(?|/)

NU networks are whitelisted, and known abusive subnets are handled in
the apache configs. closes #672