### PR TITLE
[#713] Update Logo url from NM to FSM

### DIFF
--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -2,7 +2,7 @@
   <div id='nmTop' class='row'>
     <div class='col-sm-12'>
       <div id="brandTopLogo" class='pull-left'>
-        <a class='institutionLogo' href='http://northwesternmedicine.org/?utm_source=website&amp;utm_medium=banner-link&amp;utm_campaign=GalterLibrary' target="_blank">
+        <a class='institutionLogo' href='https://www.feinberg.northwestern.edu/' target="_blank">
           <span class='alt'>Northwestern Medicine</span>
         </a>
       </div>

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -4,15 +4,15 @@ feature "HomePage", :type => :feature do
   subject { page }
   let(:user) { FactoryGirl.create(:user) }
   
-  describe 'branding' do
-    before { visit '/'}
-    
-    it 'has nm brand' do
-      expect(page).to have_selector(:css, "div a.institutionLogo")
-    end
-    
-    it 'has home link' do
-      expect(page).to have_link('DigitalHub', href: '/')
+  describe 'masthead' do
+    it 'has branding and links' do
+      visit '/'
+
+      within('#masthead') do
+        expect(page).to have_link(nil, href: "https://www.feinberg.northwestern.edu/")
+        expect(page).to have_selector(:css, "div a.institutionLogo")
+        expect(page).to have_link('DigitalHub', href: '/')
+      end
     end
   end
 


### PR DESCRIPTION
In #masthead of the header. closes #713.