### PR TITLE
Round of Dependency Updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,7 @@ gem 'browser'
 
 gem 'savon', '~> 2.11.0'
 
-gem 'nokogiri', '~> 1.8.1'
+gem 'nokogiri', '~> 1.10.9'
 
 gem 'puma'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
     concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.4)
+    crass (1.0.6)
     daemons (1.2.4)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
@@ -370,7 +370,7 @@ GEM
     logging (2.1.0)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
-    loofah (2.2.2)
+    loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
@@ -388,9 +388,9 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mimemagic (0.3.2)
-    mini_magick (4.5.1)
+    mini_magick (4.10.1)
     mini_mime (1.0.0)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
     mono_logger (1.1.0)
     multi_json (1.12.1)
@@ -404,9 +404,10 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (3.2.0)
     newrelic_rpm (3.16.1.320)
+    nio4r (2.5.2)
     noid (0.9.0)
-    nokogiri (1.8.4)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.9)
+      mini_portile2 (~> 2.4.0)
     nom-xml (0.5.4)
       activesupport (>= 3.2.18)
       i18n
@@ -458,7 +459,8 @@ GEM
       pry (~> 0.10)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
-    puma (3.11.2)
+    puma (4.3.5)
+      nio4r (~> 2.0)
     qa (1.2.0)
       activerecord-import
       deprecation
@@ -466,7 +468,7 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 4.2.0, < 6.0)
       rdf
-    rack (1.6.10)
+    rack (1.6.13)
     rack-attack (6.0.0)
       rack (>= 1.0, < 3)
     rack-mini-profiler (0.10.7)
@@ -504,7 +506,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     raindrops (0.17.0)
-    rake (12.3.1)
+    rake (13.0.1)
     rdf (1.99.1)
       link_header (~> 0.0, >= 0.0.8)
     rdf-aggregate-repo (1.99.0)
@@ -609,7 +611,7 @@ GEM
       oauth2
     ruby-ldap (0.9.20)
     ruby-prof (0.15.9)
-    rubyzip (1.2.1)
+    rubyzip (1.3.0)
     safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.6)
@@ -734,7 +736,7 @@ GEM
       rack (>= 1, < 3)
     thor (0.20.0)
     thread_safe (0.3.6)
-    tilt (2.0.5)
+    tilt (2.0.10)
     timecop (0.9.1)
     tinymce-rails (4.4.1)
       railties (>= 3.1.1)
@@ -769,7 +771,7 @@ GEM
       hashdiff
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
+    websocket-extensions (0.1.5)
     whenever (0.10.0)
       chronic (>= 0.6.3)
     xml-simple (1.1.5)
@@ -809,7 +811,7 @@ DEPENDENCIES
   kaminari!
   memory_profiler
   newrelic_rpm
-  nokogiri (~> 1.8.1)
+  nokogiri (~> 1.10.9)
   omniauth-shibboleth
   openseadragon
   osullivan


### PR DESCRIPTION
- loofah
- rack
- rubyzip. see 1.3.0 release notes for security setting fix
- nokogiri
- haml dependency
- mini_magick
- rake
- puma
- websocket-extensions

closes #701