### PR TITLE
[#745] Add Publisher to 12th General Hospital

### DIFF
--- a/lib/batch/add_publisher_for_collection_members.rb
+++ b/lib/batch/add_publisher_for_collection_members.rb
@@ -1,0 +1,15 @@
+# updates all the items in a collection with no publisher value.
+# Requires a collection_id
+
+def add_publisher_for_collection_members(collection_id:)
+  collection = Collection.find(collection_id)
+
+  puts "Checking #{collection.members.count} items in #{collection.title} for empty publisher"
+  collection.members.each do |member|
+    if member.class == Collection
+      add_publisher_for_collection_members(collection_id: member.id)
+    end
+
+    member.update(publisher: ["DigitalHub. Galter Health Sciences Library & Learning Center"]) if member.publisher.blank?
+  end
+end

--- a/lib/batch/add_publisher_to_12th_general_hospital_745.rb
+++ b/lib/batch/add_publisher_to_12th_general_hospital_745.rb
@@ -1,0 +1,5 @@
+require "#{Rails.root}/lib/batch/add_publisher_for_collection_members"
+# batch updates for https://github.com/galterlibrary/digital-repository/issues/745
+
+twelfth_general_hospital_id = "07b25bee-4a47-466a-b9b8-70d7a392fab0"
+add_publisher_for_collection_members(collection_id: twelfth_general_hospital_id)

--- a/spec/lib/batch/add_publisher_for_collection_members_spec.rb
+++ b/spec/lib/batch/add_publisher_for_collection_members_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+require "#{Rails.root}/lib/batch/add_publisher_for_collection_members"
+
+RSpec.describe 'rails runner lib/batch/add_publisher_for_collection_members.rb' do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:item) {  make_generic_file(user) }
+  let(:collection) { make_collection(user) }
+  let(:nested_item) { make_generic_file(user) }
+  let(:nested_collection) { make_collection(user) }
+
+  before do
+    item.update_attributes(publisher: [])
+    collection.update_attributes(members: [item])
+    nested_item.update_attributes(publisher: [])
+    nested_collection.update_attributes(publisher: [], members: [nested_item])
+  end
+
+  describe "#add_publisher_for_collection_members" do
+    context "for collection with no collections as members" do
+      it "should add the DigitalHub publisher" do
+        expect(item.publisher).to eq([])
+
+        add_publisher_for_collection_members(collection_id: collection.id)
+
+        item.reload
+
+        expect(item.publisher).to eq(["DigitalHub. Galter Health Sciences Library & Learning Center"])
+      end
+    end
+
+    context "for collection a collection as member" do
+      before do
+        collection.update_attributes(:members => [item, nested_collection])
+      end
+
+      it "should add the DigitalHub publisher" do
+        expect(item.publisher).to eq([])
+        expect(nested_item.publisher).to eq([])
+        expect(nested_collection.publisher).to eq([])
+
+        add_publisher_for_collection_members(collection_id: collection.id)
+
+        item.reload
+        nested_item.reload
+        nested_collection.reload
+
+        expect(item.publisher).to eq(["DigitalHub. Galter Health Sciences Library & Learning Center"])
+        expect(nested_item.publisher).to eq(["DigitalHub. Galter Health Sciences Library & Learning Center"])
+        expect(nested_collection.publisher).to eq(["DigitalHub. Galter Health Sciences Library & Learning Center"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add default DigitalHub publisher to items in the 12th General Hospital
collection without a publisher. Create method that can be reused for
other collections. closes #745