### PR TITLE
[#809] Revert Resque in Development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :development, :test do
   gem 'flamegraph'
   gem 'memory_profiler'
   gem 'timecop'
+  gem 'resque', '1.26.0'
 end
 
 gem "better_errors",  group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -444,7 +444,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     mono_logger (1.1.0)
-    multi_json (1.12.1)
+    multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nest (1.1.2)
@@ -619,7 +619,7 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
-    resque (1.27.4)
+    resque (1.26.0)
       mono_logger (~> 1.0)
       multi_json (~> 1.0)
       redis-namespace (~> 1.3)
@@ -839,6 +839,7 @@ DEPENDENCIES
   rack-mini-profiler
   rails (= 4.2.7)
   rdf-vocab
+  resque (= 1.26.0)
   riiif (= 0.2.0)
   rspec-activemodel-mocks
   rspec-rails


### PR DESCRIPTION
In development and testing, eager_load is set to false which causes
errors when trying to run resque-1.27.4. Staging and Production has
eager_load set to true. closes #809