### PR TITLE
[#827] Series IV Collection

### DIFF
--- a/lib/batch/fix_series_iv_827.rb
+++ b/lib/batch/fix_series_iv_827.rb
@@ -1,0 +1,17 @@
+# 827 Series IV Photographs Collection Changes
+# Move all records in each Series IV subcollection to Series IV collection,
+# and delete each subocllection.
+
+series_iv_collection = Collection.find("x346d4254")
+
+series_iv_collection.members.each do |subcollection|
+  if subcollection.class == Collection
+    subcollection.members.each do |member|
+      if member.class == GenericFile
+        series_iv_collection.members += [member]
+      end
+    end
+  end
+end
+
+series_iv_collection.save!


### PR DESCRIPTION
For each subcollection's GenericFile, move it 'back' one collection
level to Series IV. The subcollection to be deleted after confirming
move. closes #827