### PR TITLE
[#844] Rework Series IV Script

### DIFF
--- a/lib/batch/fix_series_iv_827.rb
+++ b/lib/batch/fix_series_iv_827.rb
@@ -3,14 +3,19 @@
 # and delete each subocllection.
 
 series_iv_collection = Collection.find("x346d4254")
+# series_iv_collection = Collection.find("fj236226r") # staging example
 
 series_iv_collection.members.each do |subcollection|
   if subcollection.class == Collection
     subcollection.members.each do |member|
-      if member.class == GenericFile
-        series_iv_collection.members += [member]
+      if member.class == Page
+        series_iv_collection.members << member
+        member.combined_file = nil
+        member.save!
       end
     end
+    subcollection.combined_file = nil
+    subcollection.save!
   end
 end
 


### PR DESCRIPTION
Items in the subcollection were Pages, and not GenericFile, and had
combined_file relation to the subcollection. Check if item is Page, and
remove the combined_file relation. closes #844