### PR TITLE
[#895] Add Owner Email and Netid to Extras

### DIFF
--- a/app/models/invenio_rdm_record_converter.rb
+++ b/app/models/invenio_rdm_record_converter.rb
@@ -63,9 +63,28 @@ class InvenioRdmRecordConverter < Sufia::Export::Converter
   end
 
   def extra_data(generic_file)
+    data = {}
+
     if !generic_file.based_near.empty?
+        data["presentation_location"] = generic_file.based_near
+    end
+    data["owner"] = owner_info(generic_file)
+
+    data
+  end
+
+  def owner_info(generic_file)
+    user = User.find_by(username: generic_file.depositor)
+
+    if user
       {
-        "presentation_location": generic_file.based_near
+        "netid": user.username,
+        "email": user.email
+      }
+    else
+      {
+        "netid": "unknown",
+        "email": "unknown"
       }
     end
   end

--- a/spec/models/invenio_rdm_record_converter_spec.rb
+++ b/spec/models/invenio_rdm_record_converter_spec.rb
@@ -162,7 +162,11 @@ RSpec.describe InvenioRdmRecordConverter do
         "content_path": generic_file_content_path
       },
       "extras": {
-        "presentation_location": generic_file.based_near
+        "presentation_location": generic_file.based_near,
+        "owner": {
+          "netid": user.username,
+          "email": user.email
+        }
       }
     }.to_json
   end
@@ -273,17 +277,19 @@ RSpec.describe InvenioRdmRecordConverter do
     end
   end
 
-  let(:expected_presentation_location) {
+  let(:expected_extra_data) {
     {
-      "presentation_location": ["'Boston, Massachusetts, United States', 'East Peoria, Illinois, United States'"]
-    }
+      "presentation_location": ["'Boston, Massachusetts, United States', 'East Peoria, Illinois, United States'"],
+      "owner": {
+        "netid": user.username,
+        "email": user.email
+      }
+    }.with_indifferent_access
   }
 
   describe "#extra_data" do
-    context "presentation_location" do
-      it "adds based_near to presentation_location" do
-        expect(converter.send(:extra_data, generic_file)).to eq(expected_presentation_location)
-      end
+    it "adds data" do
+      expect(converter.send(:extra_data, generic_file).with_indifferent_access).to eq(expected_extra_data)
     end
   end
 


### PR DESCRIPTION
The depositor for a GenericFile is used as the 'owner'. The netid is
stored as 'username' for User. Look them up and extract the netid and
email and add to Extras field. closes #895