### PR TITLE
896 record permissions

### DIFF
--- a/app/models/invenio_rdm_record_converter.rb
+++ b/app/models/invenio_rdm_record_converter.rb
@@ -69,6 +69,7 @@ class InvenioRdmRecordConverter < Sufia::Export::Converter
         data["presentation_location"] = generic_file.based_near
     end
     data["owner"] = owner_info(generic_file)
+    data["permissions"] = file_permissions(generic_file)
 
     data
   end
@@ -87,6 +88,16 @@ class InvenioRdmRecordConverter < Sufia::Export::Converter
         "email": "unknown"
       }
     end
+  end
+
+  def file_permissions(generic_file)
+    permission_data = Hash.new { |h,k| h[k] = [] }
+
+    generic_file.permissions.each do |permission|
+      permission_data[permission.access] << permission.agent_name
+    end
+
+    permission_data
   end
 
   def record_for_export(generic_file)

--- a/spec/models/invenio_rdm_record_converter_spec.rb
+++ b/spec/models/invenio_rdm_record_converter_spec.rb
@@ -166,6 +166,10 @@ RSpec.describe InvenioRdmRecordConverter do
         "owner": {
           "netid": user.username,
           "email": user.email
+        },
+        "permissions": {
+          "read": ["public"],
+          "edit": [user.username]
         }
       }
     }.to_json
@@ -283,6 +287,10 @@ RSpec.describe InvenioRdmRecordConverter do
       "owner": {
         "netid": user.username,
         "email": user.email
+      },
+      "permissions": {
+        "read": ["public"],
+        "edit": [user.username]
       }
     }.with_indifferent_access
   }

--- a/spec/models/invenio_rdm_record_converter_spec.rb
+++ b/spec/models/invenio_rdm_record_converter_spec.rb
@@ -297,7 +297,7 @@ RSpec.describe InvenioRdmRecordConverter do
 
   describe "#extra_data" do
     it "adds data" do
-      expect(converter.send(:extra_data, generic_file).with_indifferent_access).to eq(expected_extra_data)
+      expect(invenio_rdm_record_converter.send(:extra_data).with_indifferent_access).to eq(expected_extra_data)
     end
   end
 


### PR DESCRIPTION
Export the permissions for each GenericFile. Added to the "extras"
section, for each permission type(read/edit), store the user's
netid(username). closes #896