### PR TITLE
[#907] Export Formats Should Be An Array

### DIFF
--- a/app/models/invenio_rdm_record_converter.rb
+++ b/app/models/invenio_rdm_record_converter.rb
@@ -185,7 +185,7 @@ class InvenioRdmRecordConverter < Sufia::Export::Converter
       "identifiers": ark_identifiers(@generic_file.ark),
       "related_identifiers": related_identifiers(@generic_file.related_url),
       "sizes": Array.new.tap{ |size_json| size_json << "#{@generic_file.page_count} pages" if !@generic_file.page_count.blank? },
-      "formats": @generic_file.mime_type,
+      "formats": [@generic_file.mime_type],
       "version": version(@generic_file.content),
       "rights": rights(@generic_file.rights),
       "locations": {"features": @generic_file.subject_geographic.present? ? @generic_file.subject_geographic.map{ |location| {place: location} } : []},

--- a/spec/models/invenio_rdm_record_converter_spec.rb
+++ b/spec/models/invenio_rdm_record_converter_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe InvenioRdmRecordConverter do
               "relation_type": {"id": "isRelatedTo"}
             }],
           "sizes": ["#{generic_file.page_count} pages"],
-          "formats": "application/pdf",
+          "formats": ["application/pdf"],
           "version": "v1.0.0",
           "rights": [{
             "id": "CC-BY-NC-SA-3.0-US",


### PR DESCRIPTION
Update export to use array for formats field. closes #907


EDIT: just checking if these changes are not in the main codebase. 