### PR TITLE
[#939] Update Header Lookup To Only Check Local Sources

### DIFF
--- a/app/models/header_lookup.rb
+++ b/app/models/header_lookup.rb
@@ -27,9 +27,9 @@ class HeaderLookup
     if term.blank? || scheme.blank?
       nil
     elsif scheme == :mesh
-      @@memoized_mesh[term] || mesh_term_pid_local_lookup(term) || mesh_term_pid_lookup(term)
+      @@memoized_mesh[term] || mesh_term_pid_local_lookup(term) || nil
     elsif scheme == :lcsh
-      @@memoized_lcsh[term] || lcsh_term_pid_local_lookup(term) || lcsh_term_pid_lookup(term)
+      @@memoized_lcsh[term] || lcsh_term_pid_local_lookup(term) || nil
     else
       nil
     end

--- a/app/models/invenio_rdm_record_converter.rb
+++ b/app/models/invenio_rdm_record_converter.rb
@@ -293,6 +293,8 @@ class InvenioRdmRecordConverter < Sufia::Export::Converter
         {id: pid}
       elsif scheme == :subject_name || scheme == :tag
         {subject: term}
+      else
+        puts "------\nUnable to map subject\nFile Id: #{@generic_file.id} Term: #{term} Scheme: #{scheme}\n------"
       end
     end
 


### PR DESCRIPTION
Remove calls to mesh and lcsh lookup apis. When a subject lookup can not
find a term locally, output information for looking up manually.
closes #939