### PR TITLE
[#125] Dont Export Records With Missing Dois

### DIFF
--- a/app/models/generic_file.rb
+++ b/app/models/generic_file.rb
@@ -7,6 +7,11 @@ class GenericFile < ActiveFedora::Base
   include Galtersufia::GenericFile::FullTextIndexing
   include Galtersufia::GenericFile::MimeTypes
 
+  PUBLIC_PERMISSION = "http://projecthydra.org/ns/auth/group#public"
+  GV_BLACK_PHOTOGRAPH_SUB_COLLECTION_ID = "x346d4254"
+  GV_BLACK_COLLECTION_ID = "a4de96c9-7c6d-40d6-ad9e-cac8a24faad5"
+
+
   belongs_to :parent,
     predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf,
     class_name: "Collection"
@@ -136,6 +141,24 @@ class GenericFile < ActiveFedora::Base
     citation = super
     add_doi_to_citation(citation)
   end
+
+  def unexportable?
+    collection_ids = collections.map(&:id)
+
+    # if record is publc, has a doi, and is either in the gv black photograph sub collection or is not in the greater gv black collection
+    public? && !doi.empty? && (collection_ids.include?(GV_BLACK_PHOTOGRAPH_SUB_COLLECTION_ID) || !collection_ids.include?(GV_BLACK_COLLECTION_ID))
+  end
+
+  def public?
+    permissions.each do |permission|
+      if permission.agent == PUBLIC_PERMISSION
+        return true
+      end
+    end
+
+    false
+  end
+  private :public?
 
   def json_presentation_terms
     GalterGenericFilePresenter.terms -

--- a/app/models/generic_file.rb
+++ b/app/models/generic_file.rb
@@ -143,10 +143,19 @@ class GenericFile < ActiveFedora::Base
   end
 
   def unexportable?
-    collection_ids = collections.map(&:id)
+    (open_access? && doi.empty?) || in_gv_black_collection?
+  end
 
-    # if record is publc, has a doi, and is either in the gv black photograph sub collection or is not in the greater gv black collection
-    public? && !doi.empty? && (collection_ids.include?(GV_BLACK_PHOTOGRAPH_SUB_COLLECTION_ID) || !collection_ids.include?(GV_BLACK_COLLECTION_ID))
+  def open_access?
+    self.visibility == InvenioRdmRecordConverter::OPEN_ACCESS
+  end
+
+  def in_gv_black_collection?
+    parent_collections_ids = self.collection_ids
+
+    # if broader restrictions -> add additional GV black collections
+    # if less restrictive -> use only GV black photograph sub collection
+    parent_collections_ids.include?(GV_BLACK_PHOTOGRAPH_SUB_COLLECTION_ID, GV_BLACK_COLLECTION_ID)
   end
 
   def public?

--- a/app/models/invenio_rdm_record_converter.rb
+++ b/app/models/invenio_rdm_record_converter.rb
@@ -38,7 +38,10 @@ class InvenioRdmRecordConverter < Sufia::Export::Converter
   #
   # @param [GenericFile] generic_file file to be converted for export
   def initialize(generic_file=nil)
-    return unless generic_file
+    if generic_file.blank? || generic_file.unexportable?
+      return
+    end
+
     @generic_file = generic_file
 
     puts "processing file: #{@generic_file.id}"


### PR DESCRIPTION
- Add #unexportable? function to GenericFile. 
- closes galterlibrary/digitalhub-2#125
- closes #965 