### PR TITLE
replace '&' by 'and' in communities id/title

### DIFF
--- a/communities.json
+++ b/communities.json
@@ -127,9 +127,9 @@
           }
         ]
       },
-      "id": "galter-health-sciences-library-&-learning-center",
+      "id": "galter-health-sciences-library-and-learning-center",
       "metadata": {
-        "title": "Galter Health Sciences Library & Learning Center",
+        "title": "Galter Health Sciences Library and Learning Center",
         "type": "organization"
       }
     },


### PR DESCRIPTION
Honestly this is for pure synchrony: the final communities.json file is likely in galter-ir-importer or outside version control altogether. 