### PR TITLE
[#1000] Empty JSON Exports

### DIFF
--- a/app/models/generic_file.rb
+++ b/app/models/generic_file.rb
@@ -159,12 +159,12 @@ class GenericFile < ActiveFedora::Base
     gfjson
   end
 
-  def unexportable?(collection_paths)
-     open_access_and_no_doi? || in_old_gv_black_and_not_photograph?(collection_paths)
+  def unexportable?
+     open_access_and_no_doi? || in_old_gv_black_and_not_photograph?
   end
 
-  def in_old_gv_black_and_not_photograph?(collection_paths)
-    in_collections?([GV_BLACK_COLLECTION_ID], collection_paths) && !in_collections?([GV_BLACK_PHOTOGRAPH_SUB_COLLECTION_ID], collection_paths)
+  def in_old_gv_black_and_not_photograph?
+    in_collections?([GV_BLACK_COLLECTION_ID]) && !in_collections?([GV_BLACK_PHOTOGRAPH_SUB_COLLECTION_ID])
   end
   private :in_old_gv_black_and_not_photograph?
 
@@ -173,16 +173,8 @@ class GenericFile < ActiveFedora::Base
   end
   private :open_access_and_no_doi?
 
-  def in_collections?(collection_ids=[], collection_paths=[[{}]])
-    collection_paths.each do |collection_path|
-      collection_path.each do |collection_obj|
-        if collection_ids.include?(collection_obj[:id])
-          return true
-        end
-      end
-    end
-
-    false
+  def in_collections?(collection_array=[])
+    !(collection_array & self.collection_ids).empty?
   end
 
   class << self

--- a/app/models/invenio_rdm_record_converter.rb
+++ b/app/models/invenio_rdm_record_converter.rb
@@ -49,10 +49,6 @@ class InvenioRdmRecordConverter < Sufia::Export::Converter
     # communities is an array consisting of collection paths which are arrays of hashes
     @dh_collections = list_collections
 
-    if generic_file.unexportable?(@dh_collections)
-      return
-    end
-
     @record = record_for_export
     @file = file_info
     @extras = extra_data

--- a/lib/scripts/repo_export_in_batches.rb
+++ b/lib/scripts/repo_export_in_batches.rb
@@ -36,6 +36,8 @@ converters.each do |converter|
   conversion_count = 0
 
   converter[:model_class].find_each do |record_for_export|
+    next if record_for_export.unexportable?
+
     converted_record = converter[:converter_class].new(
       record_for_export, collection_store.data, role_store.data
     )


### PR DESCRIPTION
Fixes empty exported json files. Put the skip before
initializing the converter class. closes #1000