### PR TITLE
[#1013] Empty Metadata

### DIFF
--- a/app/models/invenio_rdm_record_converter.rb
+++ b/app/models/invenio_rdm_record_converter.rb
@@ -52,7 +52,7 @@ class InvenioRdmRecordConverter < Sufia::Export::Converter
   end
 
   def to_json(options={})
-    return "{}" if @generic_file.unexportable?(@dh_collections)
+    return "{}" if @generic_file.unexportable?(@dh_collections) || @record[:metadata].blank?
     options[:except] ||= ["memoized_mesh", "memoized_lcsh", "generic_file", "collection_store", "role_store", "dh_collections"]
     super
   end

--- a/spec/models/invenio_rdm_record_converter_spec.rb
+++ b/spec/models/invenio_rdm_record_converter_spec.rb
@@ -218,6 +218,16 @@ RSpec.describe InvenioRdmRecordConverter do
         allow(generic_file).to receive(:unexportable?).and_return(true)
         expect(invenio_rdm_record_converter.to_json).to eq "{}"
       end
+
+      context "empty metadata" do
+        before do
+          allow_any_instance_of(InvenioRdmRecordConverter).to receive(:invenio_metadata).and_return(nil)
+        end
+
+        it "returns blank json string" do
+          expect(invenio_rdm_record_converter.to_json).to eq "{}"
+        end
+      end
     end
   end
 


### PR DESCRIPTION
When metadata is empty have InvenioRdmRecordConverter#to_json return an
empty hash. closes #1013