### PR TITLE
[#1016] Local Mesh Lookups Raising Errors

### DIFF
--- a/app/models/header_lookup.rb
+++ b/app/models/header_lookup.rb
@@ -11,8 +11,8 @@ class HeaderLookup
   MEMOIZED_MESH_FILE = "memoized_mesh.txt"
   MEMOIZED_LCSH_FILE = "memoized_lcsh.txt"
   MEMOIZED_LCNAF_FILE = "memoized_lcnaf.txt"
-  SEARCHABLE_MESH_FILE = "subjects_mesh.yml"
-  SEARCHABLE_LCSH_FILE = "subjects_lcsh.yml"
+  SEARCHABLE_MESH_FILE = ENV['SUBJECTS_MESH_FILE']
+  SEARCHABLE_LCSH_FILE = ENV['SUBJECTS_LCSH_FILE']
   SEARCHABLE_LCNAF_FILE = "subjects_lcnaf.csv"
 
   def initialize

--- a/subjects_mesh.yml
+++ b/subjects_mesh.yml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1e7fc1b1b84709393efeb8068513603f8a45972755ca75eb07f0e16f30b0aacf
-size 69184885


### PR DESCRIPTION
Local mesh lookups are failing because git lfs is not installed on
staging or production which causes subjects_mesh.yml to not get
decompressed. Instead of using git lfs copy the subject files to each
server and add constants in local_env.rb to point to the files.
closes #1016