### PR TITLE
[#953] Missing Dates

### DIFF
--- a/app/models/invenio_rdm_record_converter.rb
+++ b/app/models/invenio_rdm_record_converter.rb
@@ -177,10 +177,10 @@ class InvenioRdmRecordConverter < Sufia::Export::Converter
         "additional_descriptions": format_additional("description", "other", @generic_file.description.drop(1)) + format_additional("description", "acknowledgements", @generic_file.acknowledgments)\
           + format_additional("description", "abstract", @generic_file.abstract),
         "publisher": @generic_file.publisher.shift,
-        "publication_date": format_publication_date(@generic_file.date_created.shift || @generic_file.date_uploaded.to_s.force_encoding("UTF-8")),
+        "publication_date": format_publication_date(@generic_file.date_created.shift.presence || @generic_file.date_uploaded.to_s.force_encoding("UTF-8")),
         "subjects": SUBJECT_SCHEMES.map{ |subject_type| subjects_for_scheme(@generic_file.send(subject_type), subject_type) }.compact.flatten.uniq,
         "contributors": contributors(@generic_file.contributor),
-        "dates": @generic_file.date_created.map{ |date| {"date": normalize_date(date), "type": {"id": "created"}, "description": "When the item was originally created."} },
+        "dates": format_dates(@generic_file.date_created),
         "languages": @generic_file.language.map{ |lang| lang.present? && lang.downcase == ENGLISH ? {"id": "eng"} : nil }.compact,
         "identifiers": ark_identifiers(@generic_file.ark),
         "related_identifiers": related_identifiers(@generic_file.related_url),
@@ -373,6 +373,16 @@ class InvenioRdmRecordConverter < Sufia::Export::Converter
 
   def format_publication_date(publication_date)
     normalize_date(publication_date)
+  end
+
+  def format_dates(dates)
+    dates.reject(&:blank?).map do |date|
+      {
+        "date": normalize_date(date),
+        "type": {"id": "created"},
+        "description": "When the item was originally created."
+      }
+    end
   end
 
   def normalize_date(date_string)

--- a/spec/models/invenio_rdm_record_converter_spec.rb
+++ b/spec/models/invenio_rdm_record_converter_spec.rb
@@ -709,6 +709,14 @@ RSpec.describe InvenioRdmRecordConverter do
     end
   end
 
+  describe "#format_dates" do
+    context "file has empty string for dated created" do
+      it "returns empty array" do
+        expect(invenio_rdm_record_converter.send(:format_dates, [""])).to eq([])
+      end
+    end
+  end
+
   describe "#normalize_date" do
     context "formatted date" do
       let(:expected_formatted_date_1){ "1907-09-06" }


### PR DESCRIPTION
Add wrapper function #format_dates to keep empty strings from adding
erroenous json to the export.  closes #953