### PR TITLE
[#1025] Combine Split Description

### DIFF
--- a/app/models/invenio_rdm_record_converter.rb
+++ b/app/models/invenio_rdm_record_converter.rb
@@ -173,9 +173,10 @@ class InvenioRdmRecordConverter < Sufia::Export::Converter
         "creators": @generic_file.creator.map{ |creator| build_creator_contributor_json(creator) },
         "title": @generic_file.title.first,
         "additional_titles": format_additional("title", "alternative-title", @generic_file.title.drop(1)),
-        "description": @generic_file.description.first,
-        "additional_descriptions": format_additional("description", "other", @generic_file.description.drop(1)) + format_additional("description", "acknowledgements", @generic_file.acknowledgments)\
-          + format_additional("description", "abstract", @generic_file.abstract),
+        "description": @generic_file.description.join("\n\n").force_encoding("UTF-8"),
+        "additional_descriptions":
+          format_additional("description", "acknowledgements", @generic_file.acknowledgments) +
+          format_additional("description", "abstract", @generic_file.abstract),
         "publisher": @generic_file.publisher.shift,
         "publication_date": format_publication_date(@generic_file.date_created.shift.presence || @generic_file.date_uploaded.to_s.force_encoding("UTF-8")),
         "subjects": SUBJECT_SCHEMES.map{ |subject_type| subjects_for_scheme(@generic_file.send(subject_type), subject_type) }.compact.flatten.uniq,

--- a/spec/models/invenio_rdm_record_converter_spec.rb
+++ b/spec/models/invenio_rdm_record_converter_spec.rb
@@ -90,9 +90,8 @@ RSpec.describe InvenioRdmRecordConverter do
               "type": {"id": "alternative-title"}
             }
           ],
-          "description": generic_file.description.shift,
-          "additional_descriptions": [{"description": generic_file.description.last, "type": {"id": "other"}},
-                                      {"description": generic_file.acknowledgments.first, "type": {"id": "acknowledgements"}},
+          "description": "This is a generic file for specs only\n\nThis is an additional description to help test",
+          "additional_descriptions": [{"description": generic_file.acknowledgments.first, "type": {"id": "acknowledgements"}},
                                       {"description": generic_file.abstract.first, "type": {"id": "abstract"}}],
           "publisher": "DigitalHub. Galter Health Sciences Library & Learning Center",
           "publication_date": "2021-01-01",


### PR DESCRIPTION
Join GenericFile#description with double new lines - "\n\n" rather than
taking the first value as the primary description and mapping the rest
to additional descriptions. closes #1025