### PR TITLE
[#1032] Geographic Subject Terms

### DIFF
--- a/build_memoized_lcnaf.rb
+++ b/build_memoized_lcnaf.rb
@@ -1,11 +1,11 @@
 header_lookup = HeaderLookup.new
+lcnaf_terms = Set.new
 
+# Build the set of terms
 GenericFile.all.each do |generic_file|
-  lcnaf_terms = generic_file.tag
-
-  if lcnaf_terms.blank?
-    next
-  else
-    lcnaf_terms.each{ |term| header_lookup.pid_lookup_by_scheme(term, :tag) }
-  end
+  generic_file.subject_name.each{ |sub_name| lcnaf_terms << sub_name }
+  generic_file.subject_geographic.each{ |sub_geo| lcnaf_terms << sub_geo }
 end
+
+# Run the lookup on the set of terms to build the cache
+lcnaf_terms.each{ |term| header_lookup.lcnaf_pid_lookup(term) }

--- a/memoized_lcnaf.txt
+++ b/memoized_lcnaf.txt
@@ -1,1 +1,1 @@
-{"Birkan, Kaarin"=>"http://id.loc.gov/authorities/names/n90699999", "birkan kaarin"=>"http://id.loc.gov/authorities/names/n90699999"}
+{"Birkan, Kaarin"=>"http://id.loc.gov/authorities/names/n90699999", "Tampa Joe"=>"http://id.loc.gov/authorities/names/n94099999", "Boston (Mass.)"=>"http://id.loc.gov/authorities/names/n79045553", "Chicago (Ill.)"=>"http://id.loc.gov/authorities/names/n78086438", "malignant"=>:absent}

--- a/memoized_lcsh.txt
+++ b/memoized_lcsh.txt
@@ -1,1 +1,1 @@
-{"Semantic Web"=>"http://id.loc.gov/authorities/subjects/sh2002000569", "Abdomen--Cancer"=>"http://id.loc.gov/authorities/subjects/sh85000095"}
+{"Semantic Web"=>"http://id.loc.gov/authorities/subjects/sh2002000569", "Abdomen--Cancer"=>"http://id.loc.gov/authorities/subjects/sh85000095", "Cancer"=>"http://id.loc.gov/authorities/subjects/sh85019492"}

--- a/memoized_mesh.txt
+++ b/memoized_mesh.txt
@@ -1,1 +1,1 @@
-{"Vocabulary, Controlled"=>"https://id.nlm.nih.gov/mesh/D018875", "Bile Duct Neoplasms"=>"https://id.nlm.nih.gov/mesh/D001650", "Burkitt Lymphoma--etiology"=>"https://id.nlm.nih.gov/mesh/D002051Q000209"}
+{"Vocabulary, Controlled"=>"https://id.nlm.nih.gov/mesh/D018875", "Bile Duct Neoplasms"=>"https://id.nlm.nih.gov/mesh/D001650", "Burkitt Lymphoma--etiology"=>"https://id.nlm.nih.gov/mesh/D002051Q000209", "Abrin"=>"https://id.nlm.nih.gov/mesh/D000036"}

--- a/spec/models/header_lookup_spec.rb
+++ b/spec/models/header_lookup_spec.rb
@@ -36,93 +36,17 @@ RSpec.describe HeaderLookup do
        }
      }"
   end
-  let(:expected_mesh_result) { "https://id.nlm.nih.gov/mesh/D018875" }
-  let(:expected_memoized_mesh) { {mesh_term=>expected_mesh_result} }
-  let(:blank_mesh_term) { "mesh term does not exist" }
-  let(:expected_failed_mesh) { "#{blank_mesh_term} - MESH" }
-
-  describe "#mesh_term_pid_lookup" do
-    context 'search returns values' do
-      before do
-        allow(HTTParty).to receive(:get).and_return(mesh_api_response)
-        @mesh_result = subject.mesh_term_pid_lookup(mesh_term)
-      end
-
-      it 'calls api with correct term' do
-        expect(HTTParty).to have_received(:get).with(mesh_query_url)
-      end
-
-      it 'returns result for mesh term' do
-        expect(@mesh_result).to eq(expected_mesh_result)
-      end
-    end
-
-    context 'search returns no values' do
-      before do
-        allow(HTTParty).to receive(:get).and_return(empty_mesh_api_response)
-        @mesh_result = subject.mesh_term_pid_lookup(blank_mesh_term)
-      end
-
-      it 'returns N/A for PID for mesh term' do
-        expect(@mesh_result).to eq(nil)
-      end
-    end
-  end
-
-  let(:lcsh_term) { "Semantic Web" }
-  let(:lcsh_query_url) { "http://id.loc.gov/authorities/subjects/suggest/?q=*Semantic+Web*" }
-  let(:lcsh_api_response) do
-    """\
-    [\"*Semantic*Web*\",[\"Semantic Web\",\"Semantic Web--Congresses\"],[\"1 result\",\"1 result\"],[\"http://id.loc.go\
-    v/authorities/subjects/sh2002000569\",\"http://id.loc.gov/authorities/subjects/sh2010112582\"]]
-    """
-  end
-  let(:empty_lcsh_api_response) { "[\"*this*is*not*a*real*search*\",[],[],[]]" }
-  let(:expected_lcsh_result) { "https://id.loc.gov/authorities/subjects/sh2002000569" }
-  let(:expected_memoized_lcsh) { {lcsh_term=>expected_lcsh_result} }
-  let(:blank_lcsh_term) { "lcsh term does not exist" }
-  let(:expected_failed_lcsh) { "#{blank_lcsh_term} - LCSH" }
-
-  describe "#lcsh_term_pid_lookup" do
-    context 'search returns values' do
-      before do
-        allow(HTTParty).to receive(:get).and_return(lcsh_api_response)
-        @lcsh_result = subject.lcsh_term_pid_lookup(lcsh_term)
-      end
-
-      it 'calls api with correct term' do
-        expect(HTTParty).to have_received(:get).with(lcsh_query_url)
-      end
-
-      # TODO figure out what to do with terms that have multiple PIDs returned from query
-      it 'returns result for lcsh term' do
-        expect(@lcsh_result).to eq(expected_lcsh_result)
-      end
-    end
-
-    context 'search returns no values' do
-      before do
-        allow(HTTParty).to receive(:get).and_return(empty_lcsh_api_response)
-        @lcsh_result = subject.lcsh_term_pid_lookup(lcsh_term)
-      end
-
-      it 'returns nil for PID for lcsh term' do
-        expect(@lcsh_result).to eq(nil)
-      end
-    end
-  end
 
   let(:no_pid_mesh_subject) { "Fake Mesh Term: DigitalHub field mesh" }
   let(:no_pid_lcsh_subject) { "Fake Lcsh Term: DigitalHub field lcsh" }
 
-  # TODO: do we want this to return nil? Should we log these values somewhere?
-  describe "#pid_lookup_by_scheme" do
+  describe "#pid_lookup_by_field" do
     it 'returns nil for subject header with no pid' do
-      expect(subject.send(:pid_lookup_by_scheme, no_pid_lcsh_subject, :lcsh)).to eq(nil)
+      expect(subject.send(:pid_lookup_by_field, no_pid_lcsh_subject, :lcsh)).to eq(nil)
     end
 
     it 'returns nil for subject header with no pid' do
-      expect(subject.send(:pid_lookup_by_scheme, no_pid_mesh_subject, :mesh)).to eq(nil)
+      expect(subject.send(:pid_lookup_by_field, no_pid_mesh_subject, :mesh)).to eq(nil)
     end
   end
 
@@ -144,16 +68,12 @@ RSpec.describe HeaderLookup do
     end
   end
 
-  let(:lcnaf_file_name) { "spec/fixtures/mock_lcnaf.yml" }
-  let(:lcnaf_term) { "New York (N.Y.). Administration for Children's Services" }
-  let(:lcnaf_id) { "http://id.loc.gov/authorities/names/n2001099999" }
-  let(:lcnaf_term2) { "Birkan, Kaarin" }
-  let(:lcnaf_id2) { "http://id.loc.gov/authorities/names/n90699999" }
+  let(:lcnaf_term) { "Birkan, Kaarin" }
+  let(:lcnaf_id) { "http://id.loc.gov/authorities/names/n90699999" }
 
   describe "#lcnaf_pid_lookup" do
     it "it returns the correct id for the lcnaf term" do
-      expect(subject.lcnaf_pid_lookup(lcnaf_term, lcnaf_file_name)).to eq(lcnaf_id)
-      expect(subject.lcnaf_pid_lookup(lcnaf_term2, lcnaf_file_name)).to eq(lcnaf_id2)
+      expect(subject.lcnaf_pid_lookup(lcnaf_term)).to eq(lcnaf_id)
     end
   end
 end

--- a/spec/models/invenio_rdm_record_converter_spec.rb
+++ b/spec/models/invenio_rdm_record_converter_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe InvenioRdmRecordConverter do
   let(:expected_mesh_id) { ::HeaderLookup::MESH_ID_URI + "D018875" }
   let(:expected_lcnaf_id) { "http://id.loc.gov/authorities/names/n90699999" }
   let(:lcsh_term) { "Semantic Web" }
-  let(:duplicate_subject_term) { "Duplicate Term" }
+  let(:duplicate_subject_term) { "Tampa Joe" }
   let(:expected_lcsh_id) { ::HeaderLookup::LCSH_ID_URI + "sh2002000569" }
   let(:generic_file_doi) { "10.5438/55e5-t5c0" }
   let(:generic_file) {
@@ -32,7 +32,7 @@ RSpec.describe InvenioRdmRecordConverter do
       date_uploaded: Time.new(2020, 2, 3),
       mesh: [mesh_term],
       lcsh: [lcsh_term],
-      subject_geographic: ["Boston, Massachusetts", "Chicago, Illinois"],
+      subject_geographic: ["Boston (Mass.)", "Chicago (Ill.)"],
       based_near: ["'Boston, Massachusetts, United States', 'East Peoria, Illinois, United States'"],
       description: ["This is a generic file for specs only", "This is an additional description to help test"],
       date_created: ["2021-1-1"],
@@ -110,6 +110,15 @@ RSpec.describe InvenioRdmRecordConverter do
             },
             {
               "id": expected_lcnaf_id
+            },
+            {
+              "id": "http://id.loc.gov/authorities/names/n94099999" # tampa joe
+            },
+            {
+              "id": "http://id.loc.gov/authorities/names/n79045553" # boston
+            },
+            {
+              "id": "http://id.loc.gov/authorities/names/n78086438" # chicago
             }
           ],
           "contributors": [{
@@ -138,9 +147,7 @@ RSpec.describe InvenioRdmRecordConverter do
             "id": "cc-by-nc-sa-3.0-us",
             "link": "http://creativecommons.org/licenses/by-nc-sa/3.0/us/",
             "title": {"en": 'Creative Commons Attribution Non Commercial Share Alike 3.0 United States'}}],
-          "locations": {
-            "features": [{"place": "Chicago, Illinois"}, {"place": "Boston, Massachusetts"}]
-          },
+          "locations": {},
           "funding": [{
             "funder": {
               "name": "National Library of Medicine (NLM)",
@@ -849,7 +856,7 @@ RSpec.describe InvenioRdmRecordConverter do
     end
   end
 
-  describe "#subjects_for_scheme" do
+  describe "#subjects_for_field" do
     context "mesh scheme" do
       let(:unknown_mesh_term){ ["nothing but lies"] }
       let(:known_mesh_term){ ["Bile Duct Neoplasms"] }
@@ -859,15 +866,15 @@ RSpec.describe InvenioRdmRecordConverter do
       let(:expected_mesh_with_qualifier_result){ [{"id": ::HeaderLookup::MESH_ID_URI + "D002051Q000209"}]}
 
       it "returns '[]' for unknown term" do
-        expect(invenio_rdm_record_converter.send(:subjects_for_scheme, unknown_mesh_term, mesh_subject_type)).to eq([])
+        expect(invenio_rdm_record_converter.send(:subjects_for_field, unknown_mesh_term, mesh_subject_type)).to eq([])
       end
 
       it "returns metadata for known term without qualifier" do
-        expect(invenio_rdm_record_converter.send(:subjects_for_scheme, known_mesh_term, mesh_subject_type)).to eq(expected_mesh_result)
+        expect(invenio_rdm_record_converter.send(:subjects_for_field, known_mesh_term, mesh_subject_type)).to eq(expected_mesh_result)
       end
 
       it "returns metadata for term with qualifier" do
-        expect(invenio_rdm_record_converter.send(:subjects_for_scheme, known_mesh_term_with_qualifier, mesh_subject_type)).to eq(expected_mesh_with_qualifier_result)
+        expect(invenio_rdm_record_converter.send(:subjects_for_field, known_mesh_term_with_qualifier, mesh_subject_type)).to eq(expected_mesh_with_qualifier_result)
       end
     end
 
@@ -878,11 +885,11 @@ RSpec.describe InvenioRdmRecordConverter do
       let(:expected_lcsh_result){ ["id": ::HeaderLookup::LCSH_ID_URI + "sh85000095"] }
 
       it "returns '[]' for unknown term" do
-        expect(invenio_rdm_record_converter.send(:subjects_for_scheme, unknown_lcsh_term, lcsh_subject_type)).to eq([])
+        expect(invenio_rdm_record_converter.send(:subjects_for_field, unknown_lcsh_term, lcsh_subject_type)).to eq([])
       end
 
       it "returns metadata for known term" do
-        expect(invenio_rdm_record_converter.send(:subjects_for_scheme, known_lcsh_term, lcsh_subject_type)).to eq(expected_lcsh_result)
+        expect(invenio_rdm_record_converter.send(:subjects_for_field, known_lcsh_term, lcsh_subject_type)).to eq(expected_lcsh_result)
       end
     end
 
@@ -892,7 +899,7 @@ RSpec.describe InvenioRdmRecordConverter do
       let(:expected_subject_name_result){ ["subject": "malignant"] }
 
       it "returns metadata for known term" do
-        expect(invenio_rdm_record_converter.send(:subjects_for_scheme, subject_name_term, subject_name_subject_type)).to eq(expected_subject_name_result)
+        expect(invenio_rdm_record_converter.send(:subjects_for_field, subject_name_term, subject_name_subject_type)).to eq(expected_subject_name_result)
       end
     end
 
@@ -903,7 +910,7 @@ RSpec.describe InvenioRdmRecordConverter do
 
 
       it "returns metadata for term" do
-        expect(invenio_rdm_record_converter.send(:subjects_for_scheme, subject_name_terms, subject_name_subject_type)).to eq(expected_lcnaf_pid)
+        expect(invenio_rdm_record_converter.send(:subjects_for_field, subject_name_terms, subject_name_subject_type)).to eq(expected_lcnaf_pid)
       end
     end
 
@@ -913,7 +920,7 @@ RSpec.describe InvenioRdmRecordConverter do
       let(:expected_tag_result){ [{"subject": tag_term}] }
 
       it "returns the tag in subject field" do
-        expect(invenio_rdm_record_converter.send(:subjects_for_scheme, tag_terms, :tag)).to eq(expected_tag_result)
+        expect(invenio_rdm_record_converter.send(:subjects_for_field, tag_terms, :tag)).to eq(expected_tag_result)
       end
     end
   end


### PR DESCRIPTION
Update export to search lcnaf file for geographic subject names. Update
build_memoized_lcnaf.rb to search lcnaf for subject_name and
subject_geographic fields to build cache. Update lcnaf searchable file
to use jsonl instead of csv. closes #1032