### PR TITLE
[#1068] 2022-08-17 Repo Export Bug Fixes

### DIFF
--- a/app/models/concerns/galtersufia/generic_file/known_organizations.rb
+++ b/app/models/concerns/galtersufia/generic_file/known_organizations.rb
@@ -7,6 +7,7 @@ module Galtersufia
         "Galter Health Sciences Library",
         "12th General Hospital",
         "Northwestern University, Medical School",
+        "Northwestern University Medical School",
         "United States Army Office of Information and Education",
         "United States. Army",
         "World's Columbian Dental Congress (1893 : Chicago, Ill.)",

--- a/app/models/invenio_rdm_record_converter.rb
+++ b/app/models/invenio_rdm_record_converter.rb
@@ -241,15 +241,23 @@ class InvenioRdmRecordConverter < Sufia::Export::Converter
     elsif dh_user.present? || creator.include?(",")
       creatibutor_json = {
         "person_or_org": {
+          "given_name": "given_name",
+          "family_name": "family_name",
+          "type": "personal"
+        }
+      }
+
+      creatibutor_json = {
+        "person_or_org": {
           "given_name": given_name,
           "family_name": family_name,
           "type": "personal"
         }
       }
 
-      if dh_user.orcid.present?
+      if dh_user&.orcid.present?
         identifiers = [{"scheme": "orcid", "identifier": dh_user.orcid.split('/').pop}]
-        creatibutor_json["person_or_org"].merge!({"identifiers": identifiers})
+        creatibutor_json[:person_or_org].merge!({"identifiers": identifiers})
       end
     # Personal record without user in database
     # Unknown / Not Identified creator


### PR DESCRIPTION
Previous refactors introduced a bug where a User object is expected, but
nil values were being referenced. Also in previous refactors creatibutor
json was updated to have identifiers under the key "person_or_org". Ruby
hashes can be constructed with strings as key, but must be looked up
with symbols. closes #1068