### PR TITLE
[#1056] Empty Funding Information For Record

### DIFF
--- a/app/models/invenio_rdm_record_converter.rb
+++ b/app/models/invenio_rdm_record_converter.rb
@@ -483,7 +483,7 @@ class InvenioRdmRecordConverter < Sufia::Export::Converter
       return []
     end
 
-    funding_sources.map do |source|
+    funding_sources.map! do |source|
       # if the source is empty except for funder scheme, return empty
       if source == BLANK_FUNDER_SOURCE
         nil

--- a/spec/models/invenio_rdm_record_converter_spec.rb
+++ b/spec/models/invenio_rdm_record_converter_spec.rb
@@ -655,6 +655,14 @@ RSpec.describe InvenioRdmRecordConverter do
         expect(invenio_rdm_record_converter.send(:funding, multiple_funding_file_id).length).to eq(2)
       end
     end
+
+    context "file has blank funding sources" do
+      let(:blank_funding_file_id) { "78254bed-92a7-4708-bcff-16383bab9ce3" }
+
+      it "returns blank array" do
+        expect(invenio_rdm_record_converter.send(:funding, blank_funding_file_id)).to eq([])
+      end
+    end
   end
 
   describe "#resource_type" do


### PR DESCRIPTION
Change map call in InvenioRdmRecordConverter#funding to mutate the array
that it is operating on resolving an issue where blank funding data was
being exported. closes #1056

Very simple fix here. Added a spec too