### PR TITLE
[#1122] Return Blank Array For Sizes As Last Alternative

### DIFF
--- a/app/models/invenio_rdm_record_converter.rb
+++ b/app/models/invenio_rdm_record_converter.rb
@@ -619,6 +619,8 @@ class InvenioRdmRecordConverter < Sufia::Export::Converter
       ["44 pages"]
     elsif !@generic_file.page_count.blank?
       ["#{@generic_file.page_count.shift} pages"]
+    else
+      []
     end
   end
 end

--- a/spec/models/invenio_rdm_record_converter_spec.rb
+++ b/spec/models/invenio_rdm_record_converter_spec.rb
@@ -1164,4 +1164,11 @@ RSpec.describe InvenioRdmRecordConverter do
       expect(invenio_rdm_record_converter.send(:owner_info, josh_elder_user.username)).to eq({'josh_the_elder' => 'JoshElder@northwestern.edu'})
     end
   end
+
+  describe "sizes" do
+    it "returns a blank array when page_count is blank" do
+      allow(generic_file).to receive(:page_count).and_return(nil)
+      expect(invenio_rdm_record_converter.send(:sizes)).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
When the page count for a file is blank return an empty array to be compatible with the Prism importer. closes #1122 