### PR TITLE
[#1100] GV Black Item Issues

### DIFF
--- a/app/models/generic_file.rb
+++ b/app/models/generic_file.rb
@@ -9,6 +9,7 @@ class GenericFile < ActiveFedora::Base
 
   GV_BLACK_PHOTOGRAPH_SUB_COLLECTION_ID = "x346d4254"
   GV_BLACK_COLLECTION_ID = "x633f100h"
+  AREYBOOK_COLLECTION_ID = "areybook"
 
   belongs_to :parent,
     predicate: ActiveFedora::RDF::Fcrepo::RelsExt.isPartOf,
@@ -160,7 +161,10 @@ class GenericFile < ActiveFedora::Base
   end
 
   def unexportable?(collection_paths)
-    open_access_and_no_doi? || in_old_gv_black_and_not_photograph?(collection_paths) || title.shift&.ends_with?("- Combined", "- combined")
+    open_access_and_no_doi? ||
+    in_old_gv_black_and_not_photograph?(collection_paths) ||
+    in_collections?([AREYBOOK_COLLECTION_ID], collection_paths) ||
+    title.shift&.ends_with?("- Combined", "- combined")
   end
 
   def in_old_gv_black_and_not_photograph?(collection_paths)

--- a/lib/scripts/repo_export_in_batches.rb
+++ b/lib/scripts/repo_export_in_batches.rb
@@ -1,10 +1,11 @@
-# Before you run this script empty the directory tmp/export/!
-#   rm -rf tmp/export/; mkdir tmp/export/
 # Run this script with the following:
 #   ./bin/rails r lib/scripts/repo_export_in_batches.rb > "$(date +'%Y-%m-%d-%H%M%S')_repo_export_in_batches.log"
-# OR
-#   rm -rf tmp/export/; mkdir tmp/export/; ./bin/rails r lib/scripts/repo_export_in_batches.rb > "$(date +'%Y-%m-%d-%H%M%S')_repo_export_in_batches.log"
-#
+
+puts "---------\nRemoving previous export (if it exists) at tmp/export\n---------"
+export_dir = "tmp/export"
+FileUtils.rm_rf(Dir[export_dir])
+FileUtils.mkdir_p(export_dir)
+
 puts "---------\nBeginning repo export at #{Time.now} #{Time.zone}\n---------"
 
 # set classes to have records exported and classes that will do the actual conversion
@@ -35,8 +36,6 @@ converters.each do |converter|
   conversion_count = 0
 
   converter[:model_class].find_each do |record_for_export|
-    next if record_for_export.is_a?(Page)
-
     converted_record = converter[:converter_class].new(
       record_for_export, collection_store.data, role_store.data
     )


### PR DESCRIPTION
Export script will now remove the previous export directory automatically if it exists. This will prevent any situations where files that had previously been exported, but are no longer being exported are still included by accident.