### PR TITLE
[#] Hotfix - Variable Misnamed For RoleStore

### DIFF
--- a/app/models/role_store.rb
+++ b/app/models/role_store.rb
@@ -10,7 +10,7 @@ class RoleStore
     josh_elder_email  = "JoshElder@northwestern.edu"
 
     Role.find_each do |role|
-      role_user_data = r.users.pluck(:username, :email).to_h
+      role_user_data = role.users.pluck(:username, :email).to_h
 
       # update Josh's email to titlecase in the role store
       if role_user_data[josh_elder_username]

--- a/spec/models/role_store_spec.rb
+++ b/spec/models/role_store_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe RoleStore do
+  let(:role_store) { RoleStore.new }
+
+  describe "#build_role_store_data" do
+    it "does not error" do
+      expect{ role_store.build_role_store_data }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Frustrating that I overlooked this. Oh well. We can do a small release after this is merged and go from there. 

Replace "r" with "role" in RoleStore#build_rolestore_data. Add spec to ensure that this method is not going to error out again.