### PR TITLE
[#451] Univeristy of Chicago Subject Not Mapping Correctly

### DIFF
--- a/memoized_lcnaf.json
+++ b/memoized_lcnaf.json
@@ -43,7 +43,7 @@
   "Morgan, William E., 1858-": "https://id.loc.gov/authorities/names/no2017056492",
   "Somalia": "https://id.loc.gov/authorities/names/no98057629",
   "University of Illinois at Chicago": "https://id.loc.gov/authorities/names/no97006109",
-  "University of Chicago": "https://id.loc.gov/authorities/names/n85815829",
+  "University of Chicago": "https://id.loc.gov/authorities/names/n79058404",
   "Northwestern University (Evanston, Ill.). Center for Nursing": "https://id.loc.gov/authorities/names/no2011082795",
   "Murphy, J. B. (John Benjamin), 1857-1916": "https://id.loc.gov/authorities/names/n85801294",
   "Thompson, Mary Harris, 1829-1895": "https://id.loc.gov/authorities/names/no2016048752",


### PR DESCRIPTION
Update memoized LCNAF terms to correctly map University of Chicago. cloes #451